### PR TITLE
Fix plink missing file error when path contains bed substring.

### DIFF
--- a/liftover_plink_beds.wdl
+++ b/liftover_plink_beds.wdl
@@ -188,7 +188,7 @@ task merge_and_split_by_chr {
     set -x -e -o pipefail
     mkdir -p autosomal_dir/
 
-    cat "~{write_lines(plink_beds)}" | sed -e 's/.bed//g' > files_to_merge.txt
+    cat "~{write_lines(plink_beds)}" | sed -e 's/\.bed//g' > files_to_merge.txt
     cat files_to_merge.txt
     ## Get memory on the machine, use 80% of the memory for each operation
     memTotal=$(head -n1 /proc/meminfo|awk '{print $2}')


### PR DESCRIPTION
The current task `merge_and_split_by_chr` crashes when the `plink_beds` files contain the substring `"bed"` in addition to the `.bed` file suffix. 
Resulting in an error in the following line:
```bash
plink --merge-list files_to_merge.txt --make-bed \
      --indiv-sort f "~{fam_file}" \
      --update-sex "~{fam_file}" 3 \
      --out "ukb_~{reference}_merged" \
      --allow-extra-chr --threads $(nproc) --memory "${memXmx_m}"
```
With the plink error:

> Error: Failed to open

This pull request fixes the problem by correcting the escaping of the `sed` regex.