### PR TITLE
Updated Dockerfile with new base, bcftools, plink, and picard.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG BCFTOOLS_VER="1.20"
 ARG PICARD_VER="3.1.1"
 ARG INSTALL_DIR="/usr/local"
 ARG PLINK1_VER="20231211"
-ARG PLINK2_VER="20240526"
+ARG PLINK2_VER="20240609"
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     build-essential \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ ARG BCFTOOLS_VER="1.20"
 ARG PICARD_VER="3.1.1"
 ARG INSTALL_DIR="/usr/local"
 ARG PLINK1_VER="20231211"
-ARG PLINK2_VER="20240609"
+ARG PLINK2_VER="20240617"
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     build-essential \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,13 @@
-FROM ubuntu:20.04
-ARG BCFTOOLS_VER="1.12"
-ARG PICARD_VER="2.26.10"
+FROM ubuntu:24.04
+ARG BCFTOOLS_VER="1.20"
+ARG PICARD_VER="3.1.1"
 ARG INSTALL_DIR="/usr/local"
-ARG PLINK_VER="20210416"
+ARG PLINK1_VER="20231211"
+ARG PLINK2_VER="20240526"
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     build-essential \
-    openjdk-8-jre-headless \
+    openjdk-21-jre-headless \
     unzip \
     liblz4-dev \
     wget \
@@ -23,10 +24,10 @@ RUN mkdir -p /opt/picard/ \
   && wget https://github.com/broadinstitute/picard/releases/download/${PICARD_VER}/picard.jar \
   && mv picard.jar /opt/picard/
 
-RUN wget https://s3.amazonaws.com/plink2-assets/alpha2/plink2_linux_avx2.zip \
-  && unzip plink2_linux_avx2.zip && mv plink2 "${INSTALL_DIR}/bin" \
-  && rm -rf plink2_linux_avx2.zip
+RUN wget https://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_${PLINK2_VER}.zip \
+  && unzip plink2_linux_avx2_${PLINK2_VER}.zip && mv plink2 "${INSTALL_DIR}/bin" \
+  && rm -rf plink2_linux_avx2_${PLINK2_VER}.zip
 
-RUN wget https://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_${PLINK_VER}.zip \
-  && unzip plink_linux_x86_64_${PLINK_VER}.zip && mv plink "${INSTALL_DIR}/bin" && mv prettify "${INSTALL_DIR}/bin" \
-  && rm -rf plink_linux_x86_64_${PLINK_VER}.zip toy.map toy.ped
+RUN wget https://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_${PLINK1_VER}.zip \
+  && unzip plink_linux_x86_64_${PLINK1_VER}.zip && mv plink "${INSTALL_DIR}/bin" && mv prettify "${INSTALL_DIR}/bin" \
+  && rm -rf plink_linux_x86_64_${PLINK1_VER}.zip toy.map toy.ped


### PR DESCRIPTION
This pull request aims to address two points:
1. Running the workflow on UK biobank array data, the `bcftools sort` command in task `picard_liftovervcf` crashed with the error (from the stderr output):

> Writing to /tmp/bcftools-sort.xYR9VD
> [buf_flush] Error: cannot write to /tmp/bcftools-sort.xYR9VD/00001.bcf
> 

On line:
```bash
bcftools sort -o "~{file_prefix}_~{reference}.vcf.gz" -O z \
        --max-mem "${memXmx_g}g" \
        "~{file_prefix}_~{reference}.vcf"
```

This problem appears to be specific to bcftools version 1.12. Upgrading to bcftools version 1.20 resolves the issue.

2. Support for ubuntu 20.04 ends in less than one year. Ubuntu 24.04 LTS is supported until April 2029.

**Scope**
This pull request only updates the Dockerfile, not the Docker image in liftover_plink_beds.wdl. I suggest that the maintainers (@yihchii ?) update the image accordingly (or, automatically with, e.g., github actions).